### PR TITLE
Fixed 12a Error highlighting

### DIFF
--- a/veeam-logs.YAML-tmLanguage
+++ b/veeam-logs.YAML-tmLanguage
@@ -5,7 +5,7 @@ fileTypes: [log]
 uuid: d09bae69-0591-4a8d-89ae-0962c77d82b4
 
 patterns:
-- match: '> (Warning|Error)|(''Failed'')|(Error:) |(Stack:)'
+- match: '> (Warning)|(Error)|(''Failed'')|(Error:) |(Stack:)'
   captures:
     '1': {name: invalid}
     '2': {name: invalid}

--- a/veeam-logs.tmLanguage
+++ b/veeam-logs.tmLanguage
@@ -35,7 +35,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>&gt; (Warning|Error)|('Failed')|(Error:) |(Stack:)</string>
+			<string>&gt; (Warning)|(Error)|('Failed')|(Error:) |(Stack:)</string>
 		</dict>
 		<dict>
 			<key>comment</key>


### PR DESCRIPTION
In 12a the developers have changed the formatting of the logs on the VBR side, so the Error pattern in callstacks is not matched anymore. Example:

11a
[16.05.2023 11:16:50] <01> Error        Failed to dispatch pending task. SessId: [b02f54b3-18f2-452f-a38c-bbd485b2187e], Task: 

12a
[17.05.2023 11:01:04.305]    <01>   Error (3)    Failed to connect to agent's endpoint 'xxx'. Host: 'xxx'.

Notice the newly added process thread and the extra spaces added. The easiest fix is to separate the (Warning | Error) pattern into (Warning) | (Error)
